### PR TITLE
Add ’main‘ field to package.json (to make use of ender.js’ package management capabilities)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "version": "1.6.1",
     "author": "tristen <@fallsemo>",
     "ender": "./ender.js",
+    "main": "./src/tablesort.js",
     "homepage": "http://tristen.ca/tablesort/demo",
     "contributors": [
       "Olivier Vaillancourt <@ovaillancourt>",


### PR DESCRIPTION
For tablesort to work with ender.js, you have to separately link the tablesort.js file. We could benefit from ender’s package management by adding the `main` field to package.json:

``` js
{
  // package.json definitions
  "ender": "./ender.js",
  "main": "./src/tablesort.js",
  // …
}
```

The following ender call would then automatically append the tablesort source code to the generated ender.js file:

``` bash
ender add tablesort
```

This works well for me. But since I am not very experienced with package.json definitions, I’m not sure if this may have any consequences for other npm packages.
