### PR TITLE
add another sort type: "dot separated numbers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A small & simple sorting component for tables written in Javascript.
 * numbers
 * currency
 * Basic dates in `dd/mm/yy` or `dd-mm-yy` format. Years can be 4 digits. Days and Months can be 1 or 2 digits.
+* Dot separated values. E.g. IP addresses or version numbers.
 
 ### Additional options
 

--- a/src/tablesort.js
+++ b/src/tablesort.js
@@ -137,8 +137,8 @@
                 sortFunction = sortDotSep;
             // Sort as number if a currency key exists or number
             } else if (item.match(/^-?[£\x24Û¢´€]?\d+\s*([,\.]\d{0,2})/) || // prefixed currency
-                     item.match(/^-?\d+\s*([,\.]\d{0,2})?[£\x24Û¢´€]/) || // suffixed currency
-                     item.match(/^-?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/) // number
+                item.match(/^-?\d+\s*([,\.]\d{0,2})?[£\x24Û¢´€]/) || // suffixed currency
+                item.match(/^-?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/) // number
             ) {
                 sortFunction = sortNumber;
             } else if (testDate(item)) {

--- a/src/tablesort.js
+++ b/src/tablesort.js
@@ -117,11 +117,29 @@
                 return parseDate(bb) - parseDate(aa);
             };
 
+            var sortDotSep = function(a, b) {
+                var aa = getInnerText(a.cells[that.col]).split('.'),
+                    bb = getInnerText(b.cells[that.col]).split('.');
+
+                for (var i = 0, len = aa.length; i < len; i++) {
+                    var aai = parseInt(aa[i]),
+                        bbi = parseInt(bb[i]);
+
+                    if (aai == bbi) continue;
+                    if (aai < bbi) return -1;
+                    if (aai > bbi) return 1;
+                }
+                return 0;
+            };
+
+            // Sort dot separted numbers, e.g. ip addresses or version numbers
+            if (/^(\d+\.)+\d+$/.test(item)) {
+                sortFunction = sortDotSep;
             // Sort as number if a currency key exists or number
-            if (item.match(/^-?[£\x24Û¢´€]?\d+\s*([,\.]\d{0,2})/) || // prefixed currency
-                item.match(/^-?\d+\s*([,\.]\d{0,2})?[£\x24Û¢´€]/) || // suffixed currency
-                item.match(/^-?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/) // number
-               ) {
+            } else if (item.match(/^-?[£\x24Û¢´€]?\d+\s*([,\.]\d{0,2})/) || // prefixed currency
+                     item.match(/^-?\d+\s*([,\.]\d{0,2})?[£\x24Û¢´€]/) || // suffixed currency
+                     item.match(/^-?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/) // number
+            ) {
                 sortFunction = sortNumber;
             } else if (testDate(item)) {
                 sortFunction = sortDate;


### PR DESCRIPTION
First of all, thanks for this fantastic project.

My project needed to support sorted IP addresses, so I implemented it myself.

The sorting method is solid as far as I can tell; you can run [this test](https://gist.github.com/ryanmjacobs/b3eab5da2780c106a2a2) for yourself if you want. As a side affect, this also brings support for version numbers just like [Sortable] (http://github.hubspot.com/sortable/docs/welcome/) does.

## demo
* [before](http://jsfiddle.net/z1j96a2k/1/)
* [after](http://jsfiddle.net/2hrka0k6/2/)