### PR TITLE
readme: change syntax highlighting from html to js

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A small & simple sorting component for tables written in Javascript.
 #### Ascending/Descending
 You can pass in options as a second parameter. Currently one option is supported: `descending: true`. By default, sort is set to ascending.
 
-``` html
+``` js
 new Tablesort(document.getElementById('table-id'), {
   descending: true
 });


### PR DESCRIPTION
A portion of the code wasn't being highlighted. This fixes it.

Here's the [rich diff](https://github.com/ryanmjacobs/tablesort/commit/786aab2e2c5ee365e918885fe432631fbed7eb21?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8).