### PR TITLE
Fix tests: check decending versions

### DIFF
--- a/src/tablesort.js
+++ b/src/tablesort.js
@@ -126,8 +126,8 @@
                         bbi = parseInt(bb[i]);
 
                     if (aai == bbi) continue;
-                    if (aai < bbi) return -1;
-                    if (aai > bbi) return 1;
+                    if (aai > bbi) return -1;
+                    if (aai < bbi) return 1;
                 }
                 return 0;
             };

--- a/test/index.html
+++ b/test/index.html
@@ -83,9 +83,9 @@
         el.dispatchEvent(event);
 
         // Test the version column has sorted
-        t.equal(table.rows[1].cells[5].innerHTML, '11.0.1');
+        t.equal(table.rows[1].cells[5].innerHTML, '31.0.1650.57');
         t.equal(table.rows[2].cells[5].innerHTML, '18.0.1284.49');
-        t.equal(table.rows[3].cells[5].innerHTML, '31.0.1650.57');
+        t.equal(table.rows[3].cells[5].innerHTML, '11.0.1');
     });
 
     tape('Sorting filesizes', function(t) {
@@ -96,7 +96,7 @@
         event.initEvent('click', true, false);
         el.dispatchEvent(event);
 
-        // Test the version column has sorted
+        // Test the filesize column has sorted
         t.equal(table.rows[1].cells[6].innerHTML, '134.56 GB');
         t.equal(table.rows[2].cells[6].innerHTML, '124k');
         t.equal(table.rows[3].cells[6].innerHTML, '134 B');


### PR DESCRIPTION
I've realized that the "dot separated numbers" test is wrong. The test should be checking for descending sort, (large values on the top, getting smaller as you go down). However, the version sort **is not** checking for that.

Compare the version sort with the filesize sort:
```js
// Test the version column has sorted                                   
t.equal(table.rows[1].cells[5].innerHTML, '11.0.1');                    
t.equal(table.rows[2].cells[5].innerHTML, '18.0.1284.49');              
t.equal(table.rows[3].cells[5].innerHTML, '31.0.1650.57');

// Test the filesize column has sorted                                   
t.equal(table.rows[1].cells[6].innerHTML, '134.56 GB');                 
t.equal(table.rows[2].cells[6].innerHTML, '124k');                      
t.equal(table.rows[3].cells[6].innerHTML, '134 B'); 
```

**Note:**
This will cause the tests to fail, but at least the tests will be correct now.

**EDIT:**
All of the tests past now! I had my '>' and '<' signs swapped. :disappointed: