### PR TITLE
Don't require a newline for the filesize sort.

### DIFF
--- a/src/tablesort.js
+++ b/src/tablesort.js
@@ -262,7 +262,7 @@
     };
 
     var testFilesize = function(item){
-        return /^\d+(\.\d+)? ?(k|M|G|T|P|E|Z|Y)?i?B?$/i.test(item);
+        return /^\d+(\.\d+)? ?(k|M|G|T|P|E|Z|Y)?i?B?/i.test(item);
     };
 
     var testNumber = function(item){
@@ -318,7 +318,7 @@
         // Ex. filesize2num("123 KB") -> 123000
         // Ex. filesize2num("123 KiB") -> 125952
         filesize2num = function(filesize) {
-            var matches = filesize.match(/^(\d+(\.\d+)?) ?((k|M|G|T|P|E|Z|Y)?i?B?)$/i);
+            var matches = filesize.match(/^(\d+(\.\d+)?) ?((k|M|G|T|P|E|Z|Y)?i?B?)/i);
 
             var num    = parseFloat(cleanNumber(matches[1])),
                 suffix = matches[3];


### PR DESCRIPTION
See issue #72.