### PR TITLE
Move CSS class setting logic above the 'return if less than two rows' in sortTable function

### DIFF
--- a/src/tablesort.js
+++ b/src/tablesort.js
@@ -129,6 +129,22 @@
 
       that.table.dispatchEvent(createEvent('beforeSort'));
 
+      // If updating an existing sort `sortDir` should remain unchanged.
+      if (update) {
+        sortDir = header.classList.contains('sort-up') ? 'sort-up' : 'sort-down';
+      } else {
+        if (header.classList.contains('sort-up')) {
+          sortDir = 'sort-down';
+        } else if (header.classList.contains('sort-down')) {
+          sortDir = 'sort-up';
+        } else {
+          sortDir = that.options.descending ? 'sort-up' : 'sort-down';
+        }
+
+        header.classList.remove(sortDir === 'sort-down' ? 'sort-up' : 'sort-down');
+        header.classList.add(sortDir);
+      }
+
       if (that.table.rows.length < 2) return;
 
       // If we force a sort method, it is not necessary to check rows
@@ -186,22 +202,6 @@
           }
           totalRows++;
         }
-      }
-
-      // If updating an existing sort `sortDir` should remain unchanged.
-      if (update) {
-        sortDir = header.classList.contains('sort-up') ? 'sort-up' : 'sort-down';
-      } else {
-        if (header.classList.contains('sort-up')) {
-          sortDir = 'sort-down';
-        } else if (header.classList.contains('sort-down')) {
-          sortDir = 'sort-up';
-        } else {
-          sortDir = that.options.descending ? 'sort-up' : 'sort-down';
-        }
-
-        header.classList.remove(sortDir === 'sort-down' ? 'sort-up' : 'sort-down');
-        header.classList.add(sortDir);
       }
 
       // Before we append should we reverse the new array or not?


### PR DESCRIPTION
Hi,

We are using a streaming rendering library with TableSort. In other words, each row gets added one at a time as the data streams in. We are running to an issue that in the initial sort call, there are less than two rows in the table, so the sortTable() logic ends early, before the CSS classes are applied, on the statement

`if (that.table.rows.length < 2) return;`

Then, when more rows are added, they are considered an 'update' and the CSS class logic is again not applied.

So, if we add the 'sort-default' class to one of the header columns, we never actually see the correct CSS classes for 'sort-up' or 'sort-down' ever applied. Moving the logic for the CSS classes above that return statement fixes the problem.

Thanks!