### PR TITLE
Add support for other elements than table, add support for saving the sorted column to cookies

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -128,6 +128,17 @@
   </div>
 </div>
 
+<table id='sort-and-save-to-cookie'>
+  <thead>
+  <tr><th class='sort-default'>Save to cookie</th></tr>
+  </thead>
+  <tbody>
+  <tr><td>2</td></tr>
+  <tr><td>1</td></tr>
+  <tr><td>3</td></tr>
+  </tbody>
+</table>
+
 <script src='tape.js'></script>
 
 <script src='../src/tablesort.js'></script>
@@ -145,12 +156,14 @@
   tableDefault = document.getElementById('sort-default');
   tableRefresh = document.getElementById('sort-refresh');
   divTable     = document.getElementById('div-table-sort');
+  tableSave    = document.getElementById('sort-and-save-to-cookie');
 
   new Tablesort(table);
   new Tablesort(tableDescend, { descending: true });
   new Tablesort(tableExclude);
   new Tablesort(tableDefault);
   new Tablesort(divTable);
+  new Tablesort(tableSave, {saveToCookie: 'saved-table'});
   var refresh = new Tablesort(tableRefresh);
 
   var rowCount = tableRefresh.rows.length;

--- a/test/index.html
+++ b/test/index.html
@@ -1,121 +1,132 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset=utf-8 />
-<title></title>
+  <meta charset=utf-8 />
+  <title></title>
 </head>
 <body>
 
 <table id='sort'>
   <thead>
-    <tr>
-      <th>#</th>
-      <th>Name</th>
-      <th>Birthday</th>
-      <th>Grocery item</th>
-      <th>Price</th>
-      <th>Version</th>
-      <th>Filesize</th>
-      <th>Insensitive</th>
-      <th>data-sort</th>
-      <th data-sort-method="monthname">Monthname</th>
-    </tr>
+  <tr>
+    <th>#</th>
+    <th>Name</th>
+    <th>Birthday</th>
+    <th>Grocery item</th>
+    <th>Price</th>
+    <th>Version</th>
+    <th>Filesize</th>
+    <th>Insensitive</th>
+    <th>data-sort</th>
+    <th data-sort-method="monthname">Monthname</th>
+  </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>2</td>
-      <td>Gonzo the Great</td>
-      <td>12-2-70</td>
-      <td>Radishes</td>
-      <td>63€</td>
-      <td>31.0.1650.57</td>
-      <td>124k</td>
-      <td>B</td>
-      <td data-sort='b'>3</td>
-      <td>February</td>
-    </tr>
-    <tr>
-      <td>1</td>
-      <td>Ernie</td>
-      <td>10/11/69</td>
-      <td>Fish</td>
-      <td>£2.79</td>
-      <td>11.0.1</td>
-      <td>134.56 GB</td>
-      <td>1</td>
-      <td data-sort='a'>2</td>
-      <td>April</td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td>Bert</td>
-      <td>10/11/1969</td>
-      <td>Broccoli</td>
-      <td>$0.79</td>
-      <td>18.0.1284.49</td>
-      <td>134 B</td>
-      <td>A</td>
-      <td data-sort='c'>1</td>
-      <td>January</td>
-    </tr>
+  <tr>
+    <td>2</td>
+    <td>Gonzo the Great</td>
+    <td>12-2-70</td>
+    <td>Radishes</td>
+    <td>63€</td>
+    <td>31.0.1650.57</td>
+    <td>124k</td>
+    <td>B</td>
+    <td data-sort='b'>3</td>
+    <td>February</td>
+  </tr>
+  <tr>
+    <td>1</td>
+    <td>Ernie</td>
+    <td>10/11/69</td>
+    <td>Fish</td>
+    <td>£2.79</td>
+    <td>11.0.1</td>
+    <td>134.56 GB</td>
+    <td>1</td>
+    <td data-sort='a'>2</td>
+    <td>April</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>Bert</td>
+    <td>10/11/1969</td>
+    <td>Broccoli</td>
+    <td>$0.79</td>
+    <td>18.0.1284.49</td>
+    <td>134 B</td>
+    <td>A</td>
+    <td data-sort='c'>1</td>
+    <td>January</td>
+  </tr>
   </tbody>
 </table>
 
 <table id='sort-descend'>
   <thead>
-    <tr><th>Numbers descending</th></tr>
+  <tr><th>Numbers descending</th></tr>
   </thead>
   <tbody>
-    <tr><td>2</td></tr>
-    <tr><td>1</td></tr>
-    <tr><td>3</td></tr>
+  <tr><td>2</td></tr>
+  <tr><td>1</td></tr>
+  <tr><td>3</td></tr>
   </tbody>
 </table>
 
 <table id='sort-exclude'>
   <thead>
-    <tr>
-      <th class='no-sort'>Column exclusion</th>
-      <th>Row exclusion</th>
-    </tr>
+  <tr>
+    <th class='no-sort'>Column exclusion</th>
+    <th>Row exclusion</th>
+  </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>2</td>
-      <td>2</td>
-    </tr>
-    <tr class='no-sort'>
-      <td>1</td>
-      <td>1</td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td>3</td>
-    </tr>
+  <tr>
+    <td>2</td>
+    <td>2</td>
+  </tr>
+  <tr class='no-sort'>
+    <td>1</td>
+    <td>1</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>3</td>
+  </tr>
   </tbody>
 </table>
 
 <table id='sort-default'>
   <thead>
-    <tr><th class='sort-default'>Sort on initialization</th></tr>
+  <tr><th class='sort-default'>Sort on initialization</th></tr>
   </thead>
   <tbody>
-    <tr><td>2</td></tr>
-    <tr><td>1</td></tr>
-    <tr><td>3</td></tr>
+  <tr><td>2</td></tr>
+  <tr><td>1</td></tr>
+  <tr><td>3</td></tr>
   </tbody>
 </table>
 
 <table id='sort-refresh'>
   <thead>
-    <tr><th class='sort-default'>Refresh method</th></tr>
+  <tr><th class='sort-default'>Refresh method</th></tr>
   </thead>
   <tbody>
-    <tr><td>2</td></tr>
-    <tr><td>1</td></tr>
-    <tr><td>3</td></tr>
+  <tr><td>2</td></tr>
+  <tr><td>1</td></tr>
+  <tr><td>3</td></tr>
   </tbody>
 </table>
+
+<div class="table" id='div-table-sort'>
+  <div class="thead">
+    <div class="tr"><div class='th'>Div table</div></div>
+  </div>
+  <div class="tbody">
+    <div class="tr"><div class="td">2</div></div>
+    <div class="tr"><div class="td">1</div></div>
+    <div class="tr"><div class="td">3</div></div>
+  </div>
+</div>
 
 <script src='tape.js'></script>
 
@@ -128,23 +139,26 @@
 
 <!-- Tests -->
 <script>
-table = document.getElementById('sort');
-tableDescend = document.getElementById('sort-descend');
-tableExclude = document.getElementById('sort-exclude');
-tableDefault = document.getElementById('sort-default');
-tableRefresh = document.getElementById('sort-refresh');
-new Tablesort(table);
-new Tablesort(tableDescend, { descending: true });
-new Tablesort(tableExclude);
-new Tablesort(tableDefault);
-var refresh = new Tablesort(tableRefresh);
+  table = document.getElementById('sort');
+  tableDescend = document.getElementById('sort-descend');
+  tableExclude = document.getElementById('sort-exclude');
+  tableDefault = document.getElementById('sort-default');
+  tableRefresh = document.getElementById('sort-refresh');
+  divTable     = document.getElementById('div-table-sort');
 
-var rowCount = tableRefresh.rows.length;
-var row = tableRefresh.insertRow(rowCount);
-var cellName = row.insertCell(0);
-    cellName.innerHTML = 0;
+  new Tablesort(table);
+  new Tablesort(tableDescend, { descending: true });
+  new Tablesort(tableExclude);
+  new Tablesort(tableDefault);
+  new Tablesort(divTable);
+  var refresh = new Tablesort(tableRefresh);
 
-refresh.refresh();
+  var rowCount = tableRefresh.rows.length;
+  var row = tableRefresh.insertRow(rowCount);
+  var cellName = row.insertCell(0);
+  cellName.innerHTML = 0;
+
+  refresh.refresh();
 </script>
 
 <script src='spec/tablesort.js'></script>

--- a/test/spec/tablesort.js
+++ b/test/spec/tablesort.js
@@ -131,3 +131,29 @@ tape('Appended row is sorted on refresh', function(t) {
 
   t.end();
 });
+
+
+tape('sort works for divs', function(t) {
+  var el = divTable.querySelector('.th:nth-child(1)');
+  var event = document.createEvent('HTMLEvents');
+
+  t.equal(divTable.getElementsByClassName('td')[0].innerHTML, '2');
+  t.equal(divTable.getElementsByClassName('td')[1].innerHTML, '1');
+  t.equal(divTable.getElementsByClassName('td')[2].innerHTML, '3');
+
+  event.initEvent('click', true, false);
+  el.dispatchEvent(event);
+
+  t.equal(divTable.getElementsByClassName('td')[0].innerHTML, '1');
+  t.equal(divTable.getElementsByClassName('td')[1].innerHTML, '2');
+  t.equal(divTable.getElementsByClassName('td')[2].innerHTML, '3');
+
+  event.initEvent('click', true, false);
+  el.dispatchEvent(event);
+
+  t.equal(divTable.getElementsByClassName('td')[0].innerHTML, '3');
+  t.equal(divTable.getElementsByClassName('td')[1].innerHTML, '2');
+  t.equal(divTable.getElementsByClassName('td')[2].innerHTML, '1');
+
+  t.end();
+});

--- a/test/spec/tablesort.js
+++ b/test/spec/tablesort.js
@@ -157,3 +157,27 @@ tape('sort works for divs', function(t) {
 
   t.end();
 });
+
+
+tape('saves sort to cookie', function(t) {
+  var el = tableSave.querySelector('th:nth-child(1)');
+  var event = document.createEvent('HTMLEvents');
+
+  event.initEvent('click', true, false);
+  el.dispatchEvent(event);
+
+  t.equal(tableSave.rows[1].cells[0].innerHTML, '3');
+  t.equal(tableSave.rows[2].cells[0].innerHTML, '2');
+  t.equal(tableSave.rows[3].cells[0].innerHTML, '1');
+
+  event.initEvent('click', true, false);
+  el.dispatchEvent(event);
+
+  t.equal(tableSave.rows[1].cells[0].innerHTML, '1');
+  t.equal(tableSave.rows[2].cells[0].innerHTML, '2');
+  t.equal(tableSave.rows[3].cells[0].innerHTML, '3');
+
+  t.equal(document.cookie, 'saved-table=0; saved-tableDir=sort-down');
+
+  t.end();
+});


### PR DESCRIPTION
I had a project where for certain reasons I had to use table like structure that I created using divs and css. I needed to add support for sorting so I expanded the tablesort in a way that it now supports other html elements than just table as long as certain css classes are included.

Example:
```
<div class="table" id='div-table-sort'>
  <div class="thead">
    <div class="tr"><div class='th'>Div table</div></div>
  </div>
  <div class="tbody">
    <div class="tr"><div class="td">2</div></div>
    <div class="tr"><div class="td">1</div></div>
    <div class="tr"><div class="td">3</div></div>
  </div>
</div>
```

I also added support for saving the sorted column to cookies when tablesort is given `saveToCookie` option where the value is the name of the cookie used.

*My editor did some funky things with the indentation please ignore those..*