### PR TITLE
Update grunt, fix license definition

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
                     '(<%= grunt.template.today("yyyy-mm-dd") %>)\n' +
                     ' * <%= pkg.homepage %>\n' +
                     ' * Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;' +
-                    ' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %>\n' +
+                    ' Licensed <%= pkg.license %>\n' +
                     '*/'
             },
             build: {

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ are gladly accepted!
 ### Contributing
 
 Tablesort relies on [Grunt](http://gruntjs.com) as its build tool. Simply run
-`grunt` to package code from any contributions you make to `src/tablesort.js`
+`npm run build` to package code from any contributions you make to `src/tablesort.js`
 before submitting pull requests.
 
 Tests are run via:

--- a/package.json
+++ b/package.json
@@ -3,25 +3,23 @@
   "description": "A sorting component for HTML tables",
   "version": "4.1.0",
   "author": "tristen",
+  "license": "MIT",
   "ender": "./ender.js",
   "main": "./src/tablesort.js",
   "homepage": "http://tristen.ca/tablesort/demo/",
   "scripts": {
+    "build": "grunt",
     "test": "tape test/test.client.js | tap-spec"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/tristen/tablesort.git"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
   "devDependencies": {
     "finalhandler": "0.2.x",
-    "grunt": "~0.4.5",
-    "grunt-contrib-uglify": "~0.5.0",
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-uglify": "^2.0.0",
     "phantomjs": "~1.9.x",
     "serve-static": "1.6.x",
     "tap-spec": "^2.2.0",


### PR DESCRIPTION
1. `licenses` array has been deprecated for a while in npm, and it uses a stringified `license` instead.
2. Installs `grunt-cli` to allow building without having `grunt` installed globally.