### PR TITLE
Upgrade phantomjs 1.9.x to phantomjs-prebuilt 2.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-uglify": "^2.0.0",
-    "phantomjs": "~1.9.x",
+    "phantomjs-prebuilt": "~2.1.x",
     "serve-static": "1.6.x",
     "tap-spec": "^2.2.0",
     "tape": "^3.0.0"

--- a/test/test.client.js
+++ b/test/test.client.js
@@ -8,7 +8,7 @@ var execFile = require('child_process').execFile;
 var http = require('http');
 var finalhandler = require('finalhandler');
 var serveStatic = require('serve-static');
-var phantombin = require('phantomjs').path;
+var phantombin = require('phantomjs-prebuilt').path;
 
 var staticHandler = serveStatic(path.join(__dirname, '/../'), {
   'index': ['index.html']


### PR DESCRIPTION
phantomjs is renamed phantomjs-prebuilt.

https://www.npmjs.com/package/phantomjs#deprecated