### PR TITLE
Trim contents for default comparison

### DIFF
--- a/src/tablesort.js
+++ b/src/tablesort.js
@@ -29,8 +29,8 @@
 
   // Default sort method if no better sort method is found
   var caseInsensitiveSort = function(a, b) {
-    a = a.toLowerCase();
-    b = b.toLowerCase();
+    a = a.trim().toLowerCase();
+    b = b.trim().toLowerCase();
 
     if (a === b) return 0;
     if (a < b) return 1;


### PR DESCRIPTION
This fixes an issue where the basic comparison could be wrong if table cells have varying amounts of whitespace before/after the actual content, as generated HTML tends to have.

```
> "a" < "b"
→ true

> " a " < "  b  "
→ false
```