### PR TITLE
Fix date sorting

### DIFF
--- a/src/sorts/tablesort.date.js
+++ b/src/sorts/tablesort.date.js
@@ -3,7 +3,7 @@
 (function(){
   var parseDate = function(date) {
     date = date.replace(/\-/g, '/');
-    date = date.replace(/(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2})/, '$1/$2/$3'); // format before getTime
+    date = date.replace(/(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})/, '$3-$2-$1'); // format before getTime
 
     return new Date(date).getTime() || -1;
   };


### PR DESCRIPTION
The search allowed for years using 2 or 4 digits, while the sorting considered only 2. The reformatting is in ISO format.