### PR TITLE
Support date formats separated by a dot/period

### DIFF
--- a/src/sorts/tablesort.date.js
+++ b/src/sorts/tablesort.date.js
@@ -3,7 +3,7 @@
 (function(){
   var parseDate = function(date) {
     date = date.replace(/\-/g, '/');
-    date = date.replace(/(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})/, '$3-$2-$1'); // format before getTime
+    date = date.replace(/(\d{1,2})[\/\-\.](\d{1,2})[\/\-\.](\d{2,4})/, '$3-$2-$1'); // format before getTime
 
     return new Date(date).getTime() || -1;
   };
@@ -11,7 +11,7 @@
   Tablesort.extend('date', function(item) {
     return (
       item.search(/(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\.?\,?\s*/i) !== -1 ||
-      item.search(/\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4}/) !== -1 ||
+      item.search(/\d{1,2}[\/\-\.]\d{1,2}[\/\-\.]\d{2,4}/) !== -1 ||
       item.search(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/i) !== -1
     ) && !isNaN(parseDate(item));
   }, function(a, b) {


### PR DESCRIPTION
Some locales, such as Germany, Austria and Norway use a dot/period to separate dates. Eg: 01.02.2019