### PR TITLE
Fix the build by fixing the (most recent) tests

### DIFF
--- a/dist/sorts/tablesort.date.min.js
+++ b/dist/sorts/tablesort.date.min.js
@@ -1,5 +1,5 @@
 /*!
- * tablesort v5.1.0 (2020-01-22)
+ * tablesort v5.2.0 (2020-06-02)
  * http://tristen.ca/tablesort/demo/
  * Copyright (c) 2020 ; Licensed MIT
 */

--- a/dist/sorts/tablesort.dotsep.min.js
+++ b/dist/sorts/tablesort.dotsep.min.js
@@ -1,5 +1,5 @@
 /*!
- * tablesort v5.1.0 (2020-01-22)
+ * tablesort v5.2.0 (2020-06-02)
  * http://tristen.ca/tablesort/demo/
  * Copyright (c) 2020 ; Licensed MIT
 */

--- a/dist/sorts/tablesort.filesize.min.js
+++ b/dist/sorts/tablesort.filesize.min.js
@@ -1,5 +1,5 @@
 /*!
- * tablesort v5.1.0 (2020-01-22)
+ * tablesort v5.2.0 (2020-06-02)
  * http://tristen.ca/tablesort/demo/
  * Copyright (c) 2020 ; Licensed MIT
 */

--- a/dist/sorts/tablesort.monthname.min.js
+++ b/dist/sorts/tablesort.monthname.min.js
@@ -1,5 +1,5 @@
 /*!
- * tablesort v5.1.0 (2020-01-22)
+ * tablesort v5.2.0 (2020-06-02)
  * http://tristen.ca/tablesort/demo/
  * Copyright (c) 2020 ; Licensed MIT
 */

--- a/dist/sorts/tablesort.number.min.js
+++ b/dist/sorts/tablesort.number.min.js
@@ -1,5 +1,5 @@
 /*!
- * tablesort v5.1.0 (2020-01-22)
+ * tablesort v5.2.0 (2020-06-02)
  * http://tristen.ca/tablesort/demo/
  * Copyright (c) 2020 ; Licensed MIT
 */

--- a/dist/tablesort.min.js
+++ b/dist/tablesort.min.js
@@ -1,5 +1,5 @@
 /*!
- * tablesort v5.1.0 (2020-01-22)
+ * tablesort v5.2.0 (2020-06-02)
  * http://tristen.ca/tablesort/demo/
  * Copyright (c) 2020 ; Licensed MIT
 */

--- a/test/spec/tablesort.js
+++ b/test/spec/tablesort.js
@@ -191,4 +191,5 @@ tape('sorts with column keys', function(t) {
   t.equal(tableSortColumnKeys.rows[1].cells[1].innerHTML, '1', 'was 1');
   t.equal(tableSortColumnKeys.rows[2].cells[1].innerHTML, '2', 'was 2');
   t.equal(tableSortColumnKeys.rows[3].cells[1].innerHTML, '3', 'was 3');
+  t.end();
 })


### PR DESCRIPTION
I think #181 broke the build [four months ago](https://travis-ci.org/github/tristen/tablesort/builds/640942715).

It's not because `phantomjs[-prebuilt]` is long dead (as @tristen [suspected back then](https://github.com/tristen/tablesort/pull/181#pullrequestreview-347022045)), but rather a missing `t.end()` at the end of that new _&ldquo;sorts with column keys&rdquo;_ section of tests. (What I don't understand is how it could be that _&ldquo;tests pass[ed] locally&rdquo;_ :man_shrugging:)

This fixes that.

I suggest we publish `5.2.1` after merging this.

/cc @harimohanraj89