### PR TITLE
Include td data-sort-column-key="price" in demo

### DIFF
--- a/demo/index.md
+++ b/demo/index.md
@@ -224,17 +224,17 @@ This example sorts products by price, even though the prices are not in the same
   <tr>
     <td>Apples</td>
     <td>Sale!</td>
-    <td>20</td>
+    <td data-sort-column-key="price">20</td>
   </tr>
   <tr>
     <td>Bread</td>
     <td>Out of stock</td>
-    <td>10</td>
+    <td data-sort-column-key="price">10</td>
   </tr>
   <tr>
     <td>Radishes</td>
     <td>In Stock!</td>
-    <td>30</td>
+    <td data-sort-column-key="price">30</td>
   </tr>
 </tbody>
 </table>


### PR DESCRIPTION
The example markup for the "Sorting by column keys" demo includes the key selector in the header th cells, but not their td cells. Without this, the example is confusing as it is unclear how the selector maps to the cells. The interactive table in the demo is correct, so I suggest updating the example markup to match.