### PR TITLE
Include a dice (🎲) sorting function

### DIFF
--- a/src/sorts/tablesort.dice.js
+++ b/src/sorts/tablesort.dice.js
@@ -1,0 +1,37 @@
+(function(){
+  var cleanNumber = function(i) {
+
+    var match = i.match(/^(\d*)[dD](\d*)/);    // To parse the numbre of dices, and their type
+    var minus = i.match(/[dD]\d?\s?[-](\d?)/); // To parse the bonus
+    var plus  = i.match(/[dD]\d?\s?[+](\d?)/); // To parse the malus
+
+    if (minus) { malus = parseInt(minus[1]) } else { malus = 0 }
+    if (plus)  { bonus = parseInt(plus[1])  } else { bonus = 0 }
+    if (match) {
+      moy = ( parseInt(match[2]) + 1 ) / 2; // To handle D2, D6, D100, ...
+    }
+
+    // average = match[1] * moy + parseInt(bonus) - parseInt(malus);
+    average = match[1] * moy + bonus - malus;
+    return average;
+  },
+
+  compareNumber = function(a, b) {
+    a = parseFloat(a);
+    b = parseFloat(b);
+
+    a = isNaN(a) ? 0 : a;
+    b = isNaN(b) ? 0 : b;
+
+    return a - b;
+  };
+
+  Tablesort.extend('dice', function(item) {
+    return item.match(/^\d*[dD]\d*/);
+  }, function(a, b) {
+    a = cleanNumber(a);
+    b = cleanNumber(b);
+
+    return compareNumber(b, a);
+  });
+}());


### PR DESCRIPTION
Hello,

I discovered your project (an awesome one), and I created a new fonction to be able to sort dice results.

Why ?
Because for many role play games, player characteristics are displayed with a number of dice and a bonus/malus
Player1 Strength : 3D6 +2
Player2 Strength : 2D4 -1

I needed to parse and sort these, as I can't compare them as strings
Comparing '3D6 +2' and '2D4 -1' means nothing per se.
So basically I extract the number of dice, the eventual bonus/malus, calc the average, and sort this result

It works well using the 5.2.0 release, as its the one I'm using on my side

Spoiler alert: I'm really not a JS developper, so my commit might looks crappy.
I did my best though !