### PR TITLE
Require tablesort.js inside sorts (for webpack compability)

### DIFF
--- a/src/sorts/tablesort.date.js
+++ b/src/sorts/tablesort.date.js
@@ -1,3 +1,5 @@
+var Tablesort = require("../tablesort.js")
+
 // Basic dates in dd/mm/yy or dd-mm-yy format.
 // Years can be 4 digits. Days and Months can be 1 or 2 digits.
 (function(){

--- a/src/sorts/tablesort.dotsep.js
+++ b/src/sorts/tablesort.dotsep.js
@@ -1,3 +1,5 @@
+var Tablesort = require("../tablesort.js")
+
 // Dot separated values. E.g. IP addresses or version numbers.
 Tablesort.extend('dotsep', function(item) {
   return /^(\d+\.)+\d+$/.test(item);

--- a/src/sorts/tablesort.filesize.js
+++ b/src/sorts/tablesort.filesize.js
@@ -1,3 +1,5 @@
+var Tablesort = require("../tablesort.js")
+
 // Filesizes. e.g. '5.35 K', '10 MB', '12.45 GB', or '4.67 TiB'
 (function(){
   var compareNumber = function(a, b) {

--- a/src/sorts/tablesort.monthname.js
+++ b/src/sorts/tablesort.monthname.js
@@ -1,3 +1,5 @@
+var Tablesort = require("../tablesort.js")
+
 (function(){
 
   Tablesort.extend('monthname', function(item) {

--- a/src/sorts/tablesort.number.js
+++ b/src/sorts/tablesort.number.js
@@ -1,3 +1,5 @@
+var Tablesort = require("../tablesort.js")
+
 (function(){
   var cleanNumber = function(i) {
     return i.replace(/[^\-?0-9.]/g, '');


### PR DESCRIPTION
Hey wanted to use this library with webpack, but the sorters don't know about `Tablesort` without requiring it.