### PR TITLE
fix css arrows to be pointing in the correct direction

### DIFF
--- a/tablesort.css
+++ b/tablesort.css
@@ -17,7 +17,7 @@ th[role=columnheader]:not(.no-sort):after {
 	user-select: none;
 }
 
-th[aria-sort=ascending]:not(.no-sort):after {
+th[aria-sort=descending]:not(.no-sort):after {
 	border-bottom: none;
 	border-width: 4px 4px 0;
 }


### PR DESCRIPTION
Thanks for the great library!

It appears that the css for the aria-sort is creating the arrows in the opposite direction:

<img width="1002" alt="Screen Shot 2022-05-13 at 12 20 14 PM" src="https://user-images.githubusercontent.com/6545515/168326154-f790714c-5b83-432f-9818-16719ceaf808.png">

The name column is correctly assorted ascending, but the arrow is pointing down instead of up.

This PR changes the CSS so the arrows point in the correct direction.