### PR TITLE
Adding `sortCanceled`. Passing header in Event details.

### DIFF
--- a/src/tablesort.js
+++ b/src/tablesort.js
@@ -10,14 +10,14 @@
 
   var sortOptions = [];
 
-  var createEvent = function(name) {
+  var createEvent = function(name, detail) {
     var evt;
 
-    if (!window.CustomEvent || typeof window.CustomEvent !== 'function') {
+    if (!window.CustomEvent || typeof window.CustomEvent !== 'function') { // IE
       evt = document.createEvent('CustomEvent');
-      evt.initCustomEvent(name, false, false, undefined);
+      evt.initCustomEvent(name, /*canBubble:*/ false, /*cancelable:*/ false, detail);
     } else {
-      evt = new CustomEvent(name);
+      evt = new CustomEvent(name, { detail: detail });
     }
 
     return evt;
@@ -144,7 +144,7 @@
           sortMethod = header.getAttribute('data-sort-method'),
           sortOrder = header.getAttribute('aria-sort');
 
-      that.table.dispatchEvent(createEvent('beforeSort'));
+      that.table.dispatchEvent(createEvent('beforeSort', { header: header, update: update }));
 
       // If updating an existing sort, direction should remain unchanged.
       if (!update) {
@@ -159,7 +159,10 @@
         header.setAttribute('aria-sort', sortOrder);
       }
 
-      if (that.table.rows.length < 2) return;
+      if( that.table.rows.length < 2 ) {
+        that.table.dispatchEvent(createEvent('sortCanceled', { header: header, update: update }));
+        return;
+      }
 
       // If we force a sort method, it is not necessary to check rows
       if (!sortMethod) {
@@ -183,7 +186,10 @@
           i++;
         }
 
-        if (!items) return;
+        if (!items) {
+          that.table.dispatchEvent(createEvent('sortCanceled', { header: header, update: update }));
+          return;
+        }
       }
 
       for (i = 0; i < sortOptions.length; i++) {
@@ -259,7 +265,7 @@
         }
       }
 
-      that.table.dispatchEvent(createEvent('afterSort'));
+      that.table.dispatchEvent(createEvent('afterSort', { header: header, update: update }));
     },
 
     refresh: function() {


### PR DESCRIPTION
In a recent project I need to show or hide certain table content based on which column the user wants to sort-by. Currently I'm only able to do this in the `afterSort` event by inspecting the `<thead>` for `tr > *[aria-sort]` - but this isn't ideal.

Ideally I'd like to filter/edit data in the `beforeSort` event, however this isn't possible before the `beforeSort` event is raised before the `aria-sort=""` attributes are updated.

...so this PR uses `CustomEvent`'s `detail` property to allow the listener of `afterSort` and `beforeSort` to get the `header` (`<th>`) and `update` values.

I've also added a new event: `sortCanceled`, as `tableSort` function can `return` after calling `beforeSort` without calling `afterSort` if there's no data to sort, which I think violates expectations about the pairing of events.
