### PR TITLE
Fix dotsep sort for unequal segment counts

### DIFF
--- a/dist/sorts/tablesort.dotsep.min.js
+++ b/dist/sorts/tablesort.dotsep.min.js
@@ -3,4 +3,4 @@
  * http://tristen.ca/tablesort/demo/
  * Copyright (c) 2025 ; Licensed MIT
 */
-Tablesort.extend("dotsep",function(t){return/^(\d+\.)+\d+$/.test(t)},function(t,r){t=t.split("."),r=r.split(".");for(var e,n,i=0,s=t.length;i<s;i++)if((e=parseInt(t[i],10))!==(n=parseInt(r[i],10))){if(n<e)return-1;if(e<n)return 1}return 0});
+Tablesort.extend("dotsep",function(t){return/^(\d+\.)+\d+$/.test(t)},function(t,r){t=t.split("."),r=r.split(".");for(var e,n,i=0,s=Math.max(t.length,r.length);i<s;i++){e=parseInt(i<t.length?t[i]:"0",10),n=parseInt(i<r.length?r[i]:"0",10);if(e!==n){if(n<e)return-1;if(e<n)return 1}}return 0});

--- a/src/sorts/tablesort.dotsep.js
+++ b/src/sorts/tablesort.dotsep.js
@@ -5,9 +5,9 @@ Tablesort.extend('dotsep', function(item) {
   a = a.split('.');
   b = b.split('.');
 
-  for (var i = 0, len = a.length, ai, bi; i < len; i++) {
-    ai = parseInt(a[i], 10);
-    bi = parseInt(b[i], 10);
+  for (var i = 0, len = Math.max(a.length, b.length), ai, bi; i < len; i++) {
+    ai = parseInt(i < a.length ? a[i] : '0', 10);
+    bi = parseInt(i < b.length ? b[i] : '0', 10);
 
     if (ai === bi) continue;
     if (ai > bi) return -1;

--- a/test/index.html
+++ b/test/index.html
@@ -205,6 +205,19 @@
   </tbody>
 </table>
 
+<table id="sort-dotsep">
+  <thead>
+    <tr>
+      <th>Version</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>6.8</td></tr>
+    <tr><td>6.8.2</td></tr>
+    <tr><td>6.7.1</td></tr>
+  </tbody>
+</table>
+
 <table id="sort-custom-attribute">
   <thead>
     <tr>
@@ -248,6 +261,7 @@ tableMulti = document.getElementById('sort-multi');
 tableSortRowSet = document.getElementById('sort-row-set');
 tableSortRowAuto = document.getElementById('sort-row-auto');
 tableSortColumnKeys = document.getElementById('sort-column-keys');
+tableSortDotsep = document.getElementById('sort-dotsep');
 tableSortCustomAttr = document.getElementById('sort-custom-attribute');
 new Tablesort(table);
 new Tablesort(tableDescend, { descending: true });
@@ -257,6 +271,7 @@ new Tablesort(tableMulti);
 new Tablesort(tableSortRowSet);
 new Tablesort(tableSortRowAuto);
 new Tablesort(tableSortColumnKeys);
+new Tablesort(tableSortDotsep);
 new Tablesort(tableSortCustomAttr, { sortAttribute: "data-realname" });
 var refresh = new Tablesort(tableRefresh);
 

--- a/test/spec/dotsep.js
+++ b/test/spec/dotsep.js
@@ -25,3 +25,26 @@ tape('sorts dot separated numbers', function(t) {
 
   t.end();
 });
+
+tape('sorts versions with unequal segment counts', function(t) {
+  var el = tableSortDotsep.querySelector('th');
+  var event = document.createEvent('HTMLEvents');
+
+  // Ascending: 6.7.1 < 6.8 (= 6.8.0) < 6.8.2
+  event.initEvent('click', true, false);
+  el.dispatchEvent(event);
+
+  t.equal(tableSortDotsep.rows[1].cells[0].innerHTML, '6.7.1');
+  t.equal(tableSortDotsep.rows[2].cells[0].innerHTML, '6.8');
+  t.equal(tableSortDotsep.rows[3].cells[0].innerHTML, '6.8.2');
+
+  // Descending: 6.8.2 > 6.8 > 6.7.1
+  event.initEvent('click', true, false);
+  el.dispatchEvent(event);
+
+  t.equal(tableSortDotsep.rows[1].cells[0].innerHTML, '6.8.2');
+  t.equal(tableSortDotsep.rows[2].cells[0].innerHTML, '6.8');
+  t.equal(tableSortDotsep.rows[3].cells[0].innerHTML, '6.7.1');
+
+  t.end();
+});


### PR DESCRIPTION
## Summary

The `dotsep` comparator only iterated over `a.length` segments, so version strings with different numbers of segments (e.g. `6.8` vs `6.8.2`) were treated as equal. This fix iterates over the longer of the two arrays and treats missing segments as `0`, so `6.8` (= `6.8.0`) correctly sorts before `6.8.2`.

Fixes #258
See also #79

## Changes

- **`src/sorts/tablesort.dotsep.js`** — use `Math.max(a.length, b.length)` as loop bound; default missing segments to `0`
- **`dist/sorts/tablesort.dotsep.min.js`** — updated minified build
- **`test/index.html`** — added a dedicated `sort-dotsep` table with version data that has unequal segment counts (`6.7.1`, `6.8`, `6.8.2`)
- **`test/spec/dotsep.js`** — added test case verifying correct ascending/descending order for unequal-length versions